### PR TITLE
corrected name of cucumber-js binary

### DIFF
--- a/shouty-js/cyber-dojo.sh
+++ b/shouty-js/cyber-dojo.sh
@@ -7,7 +7,7 @@ n use ${NODE_VERSION} /usr/local/lib/node_modules/jasmine/bin/jasmine \
   JASMINE_CONFIG_PATH=tests/jasmine.json
 
 # You have to cd to a specific folder because
-#   ~/node_modules/cucumber/bin/cucumber.js
+#   ~/node_modules/cucumber/bin/cucumber-js
 # contains the line
 # require('../lib/cli/run.js').default();
 # Go figure!
@@ -19,7 +19,7 @@ export NODE_PATH=/home/$CYBER_DOJO_AVATAR_NAME/node_modules
 echo CUCUMBER FEATURES
 echo =================
 
-./cucumber.js \
+./cucumber-js \
   --format-options '{"colorsEnabled":false}' \
   --format-options '{"snippetInterface":"synchronous"}' \
   ${CYBER_DOJO_SANDBOX}/features/*.feature


### PR DESCRIPTION
Currently, running the shouty.js cyber-dojo throws an error because it cannot find the cucumber-js binary from the shell file.